### PR TITLE
DSND-3002: Retry more error types in the officer-search-consumer

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerssearch/subdelta/search/ResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/officerssearch/subdelta/search/ResponseHandler.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.officerssearch.subdelta.search;
 
 import static uk.gov.companieshouse.officerssearch.subdelta.Application.NAMESPACE;
 
+import java.util.Arrays;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -16,6 +17,7 @@ import uk.gov.companieshouse.officerssearch.subdelta.logging.DataMapHolder;
 public class ResponseHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
+    private static final String API_INFO_RESPONSE_MESSAGE = "Call to API failed, status code: %d. %s";
 
     public void handle(String message, URIValidationException ex) {
         LOGGER.error(message, ex, DataMapHolder.getLogMap());
@@ -30,12 +32,15 @@ public class ResponseHandler {
     }
 
     public void handle(String message, ApiErrorResponseException ex) {
-        if (HttpStatus.valueOf(ex.getStatusCode()).is5xxServerError()) {
-            LOGGER.info(message, DataMapHolder.getLogMap());
-            throw new RetryableException(message, ex);
-        } else {
+
+        if (HttpStatus.BAD_REQUEST.value() == ex.getStatusCode() || HttpStatus.CONFLICT.value() == ex.getStatusCode()) {
             LOGGER.error(message, ex, DataMapHolder.getLogMap());
             throw new NonRetryableException(message, ex);
+        } else {
+            LOGGER.info(
+                    String.format(API_INFO_RESPONSE_MESSAGE, ex.getStatusCode(), Arrays.toString(ex.getStackTrace())),
+                    DataMapHolder.getLogMap());
+            throw new RetryableException(message, ex);
         }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/officerssearch/subdelta/search/ResponseHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerssearch/subdelta/search/ResponseHandlerTest.java
@@ -61,7 +61,7 @@ class ResponseHandlerTest {
     @Test
     void handleApiErrorResponseExceptionNonRetryableBadRequest() {
         // given
-        HttpResponseException.Builder builder = new HttpResponseException.Builder(400, "unauthorized", new HttpHeaders());
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(400, "Bad request", new HttpHeaders());
         ApiErrorResponseException apiErrorResponseException = new ApiErrorResponseException(builder);
 
         // when
@@ -75,7 +75,7 @@ class ResponseHandlerTest {
     @Test
     void handleApiErrorResponseExceptionNonRetryableConflict() {
         // given
-        HttpResponseException.Builder builder = new HttpResponseException.Builder(409, "unauthorized", new HttpHeaders());
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(409, "Conflict", new HttpHeaders());
         ApiErrorResponseException apiErrorResponseException = new ApiErrorResponseException(builder);
 
         // when

--- a/src/test/java/uk/gov/companieshouse/officerssearch/subdelta/search/ResponseHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerssearch/subdelta/search/ResponseHandlerTest.java
@@ -13,7 +13,6 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.officerssearch.subdelta.exception.NonRetryableException;
 import uk.gov.companieshouse.officerssearch.subdelta.exception.RetryableException;
-import uk.gov.companieshouse.officerssearch.subdelta.search.ResponseHandler;
 
 @ExtendWith(MockitoExtension.class)
 class ResponseHandlerTest {
@@ -60,19 +59,41 @@ class ResponseHandlerTest {
     }
 
     @Test
-    void handleApiErrorResponseExceptionNonRetryable() {
+    void handleApiErrorResponseExceptionNonRetryableBadRequest() {
         // given
-        HttpResponseException.Builder builder = new HttpResponseException.Builder(404, "not found",
-                new HttpHeaders());
-        ApiErrorResponseException apiErrorResponseException = new ApiErrorResponseException(
-                builder);
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(400, "unauthorized", new HttpHeaders());
+        ApiErrorResponseException apiErrorResponseException = new ApiErrorResponseException(builder);
 
         // when
-        Executable executable = () -> responseHandler.handle("failed message",
-                apiErrorResponseException);
+        Executable executable = () -> responseHandler.handle("failed message", apiErrorResponseException);
 
         // then
         NonRetryableException exception = assertThrows(NonRetryableException.class, executable);
+        assertEquals("failed message", exception.getMessage());
+    }
+
+    @Test
+    void handleApiErrorResponseExceptionNonRetryableConflict() {
+        // given
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(409, "unauthorized", new HttpHeaders());
+        ApiErrorResponseException apiErrorResponseException = new ApiErrorResponseException(builder);
+
+        // when
+        Executable executable = () -> responseHandler.handle("failed message", apiErrorResponseException);
+        // then
+        NonRetryableException exception = assertThrows(NonRetryableException.class, executable);
+        assertEquals("failed message", exception.getMessage());
+    }
+    @Test
+    void handleApiErrorResponseExceptionWhenNotFound() {
+        // given
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(404, "not found", new HttpHeaders());
+        ApiErrorResponseException apiErrorResponseException = new ApiErrorResponseException(builder);
+        // when
+        Executable executable = () -> responseHandler.handle("failed message", apiErrorResponseException);
+
+        // then
+        RetryableException exception = assertThrows(RetryableException.class, executable);
         assertEquals("failed message", exception.getMessage());
     }
 }


### PR DESCRIPTION
## Describe the changes

Only 400 and 409 API responses are now non-retryable

### Related Jira tickets
[DSND-3002](https://companieshouse.atlassian.net/browse/DSND-3002)

## Developer check list
### General
- [x] Is the PR as small as it can be?
- [x] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-3002]: https://companieshouse.atlassian.net/browse/DSND-3002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ