### PR TITLE
use latest dependency-check setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 artifact_name       := officers-search-consumer
 version             := latest
 
+dependency_check_base_suppressions:=common_suppressions_spring_6.xml
+dependency_check_suppressions_repo_branch:=main
+dependency_check_minimum_cvss := 4
+dependency_check_assembly_analyzer_enabled := false
+dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
+suppressions_file := target/suppressions.xml
+
 .PHONY: all
 all: build
 
@@ -53,3 +60,36 @@ sonar:
 .PHONY: sonar-pr-analysis
 sonar-pr-analysis:
 	mvn sonar:sonar -P sonar-pr-analysis
+
+.PHONY: dependency-check
+dependency-check:
+	@ if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
+		suppressions_home="$${DEPENDENCY_CHECK_SUPPRESSIONS_HOME}"; \
+	fi; \
+	if [ ! -d "$${suppressions_home}" ]; then \
+	    suppressions_home_target_dir="./target/dependency-check-suppressions"; \
+		if [ -d "$${suppressions_home_target_dir}" ]; then \
+			suppressions_home="$${suppressions_home_target_dir}"; \
+		else \
+			mkdir -p "./target"; \
+			git clone $(dependency_check_suppressions_repo_url) "$${suppressions_home_target_dir}" && \
+				suppressions_home="$${suppressions_home_target_dir}"; \
+			if [ -d "$${suppressions_home_target_dir}" ] && [ -n "$(dependency_check_suppressions_repo_branch)" ]; then \
+				cd "$${suppressions_home}"; \
+				git checkout $(dependency_check_suppressions_repo_branch); \
+				cd -; \
+			fi; \
+		fi; \
+	fi; \
+	suppressions_path="$${suppressions_home}/suppressions/$(dependency_check_base_suppressions)"; \
+	if [  -f "$${suppressions_path}" ]; then \
+		cp -av "$${suppressions_path}" $(suppressions_file); \
+		mvn org.owasp:dependency-check-maven:check -Dformats="json,html" -DprettyPrint -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
+	else \
+		printf -- "\n ERROR Cannot find suppressions file at '%s'\n" "$${suppressions_path}" >&2; \
+		exit 1; \
+	fi
+
+.PHONY: security-check
+security-check: dependency-check
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,8 @@
   <parent>
     <groupId>uk.gov.companieshouse</groupId>
     <artifactId>companies-house-parent</artifactId>
-    <version>1.3.1</version>
+    <version>2.1.11</version>
+    <relativePath/>
   </parent>
 
   <name>officers-search-consumer</name>


### PR DESCRIPTION
8f5dd1c Add dependency-check to Makefile
The dependency-check target fetches suppressions from
 dependency-check-suppressions/main.

7d8abba Update parent pom to 2.1.11, use relativePath
2.1.11 brings in latest correct dependency-check settings.
relativePath prevents Maven from searching locally for the parent pom,
 forcing it to go to the standard Maven repositories.
Caution should be exercised here, as the parent pom version jump is
 major.

Fixes [CC-1908](https://companieshouse.atlassian.net/browse/CC-1908)

[CC-1908]: https://companieshouse.atlassian.net/browse/CC-1908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ