### PR TITLE
Enabling Centralized Vulnerability Scan CC-2685

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,6 @@
 artifact_name       := officers-search-consumer
 version             := "unversioned"
 
-dependency_check_base_suppressions:=common_suppressions_spring_6.xml
-dependency_check_suppressions_repo_branch:=main
-dependency_check_minimum_cvss := 4
-dependency_check_assembly_analyzer_enabled := false
-dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
-suppressions_file := target/suppressions.xml
-
 .PHONY: all
 all: build
 
@@ -59,9 +52,3 @@ sonar:
 .PHONY: sonar-pr-analysis
 sonar-pr-analysis:
 	mvn sonar:sonar -P sonar-pr-analysis
-
-.PHONY: security-check
-security-check:
-	mvn org.owasp:dependency-check-maven:update-only
-	mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=4 -DassemblyAnalyzerEnabled=false
-

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.11</version>
+        <version>2.1.12</version>
         <relativePath/>
     </parent>
 
@@ -23,17 +23,19 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring.boot.version>3.4.6</spring.boot.version>
-        <structured-logging.version>3.0.32</structured-logging.version>
-        <private-api-sdk-java.version>4.0.306</private-api-sdk-java.version>
-        <kafka-models.version>3.0.17</kafka-models.version>
+        <spring.boot.version>3.5.3</spring.boot.version>
+        <structured-logging.version>3.0.36</structured-logging.version>
+        <private-api-sdk-java.version>4.0.325</private-api-sdk-java.version>
+        <kafka-models.version>3.0.18</kafka-models.version>
         <test-containers.version>1.21.0</test-containers.version>
         <skip.integration.tests>false</skip.integration.tests>
         <mockito-core.version>5.17.0</mockito-core.version>
         <mockito-junit-jupiter.version>5.17.0</mockito-junit-jupiter.version>
         <jib.version>3.4.5</jib.version>
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>3.0.0</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
+        <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
     </properties>
 
     <dependencyManagement>
@@ -85,6 +87,19 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
+            <!-- Excluding org.apache.commons:commons-lang3 from structured-logging as it has a vulnerability. This will be resolved as per CC-2686. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Manually overriding the version of commons-lang3 due to a vulnerability in structured-logging. This will be resolved as per CC-2686. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/suppress.xml
+++ b/suppress.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-
-</suppressions>


### PR DESCRIPTION
This commit will remove the dependency check section from the Makefile as a part of migrating to a centralized vulnerability scanning approach managed via the CI pipeline ,Update parent pom to 2.1.12, using relativePath 2.1.12 brings in updated dependency-check settings,remove defunct suppress.xml. for the repo resolves https://companieshouse.atlassian.net/browse/CC-2685

## Describe the changes

### Related Jira tickets
[Jira Ticket](URL)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._
