### PR TITLE
Fix reported vulnerabilities in dependency track

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,9 @@
         <skip.unit.tests>false</skip.unit.tests>
         <skip.integration.tests>false</skip.integration.tests>
 
+        <!-- The tomcat-embed dependencies can be removed if spring-boot > 4.0.6 fixed the vulnerabilities-->
+        <tomcat-embed.version>11.0.22</tomcat-embed.version>
+
         <!--sonar configuration-->
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
         <sonar.login></sonar.login>
@@ -62,6 +65,24 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <!-- The tomcat-embed dependencies can be removed if spring-boot > 4.0.6 fixed the vulnerabilities-->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${tomcat-embed.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-websocket</artifactId>
+            <version>${tomcat-embed.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-el</artifactId>
+            <version>${tomcat-embed.version}</version>
+        </dependency>
         <!-- start fixes to vulnerable transitive dependencies-->
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This pull request updates the project's dependencies to address vulnerabilities related to Tomcat by explicitly adding and versioning the `tomcat-embed` modules in the `pom.xml`. These dependencies can be removed in the future if a newer version of Spring Boot resolves the vulnerabilities.

Dependency management and security:

* Added explicit dependencies for `tomcat-embed-core`, `tomcat-embed-websocket`, and `tomcat-embed-el` at version `11.0.22` to the `pom.xml` to mitigate known vulnerabilities.
* Introduced a `tomcat-embed.version` property to centralize the version management of Tomcat embed dependencies.