### PR TITLE
Add healthcheck parameters for task container startup delay

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -40,6 +40,12 @@ module "ecs-service" {
   healthcheck_matcher               = local.healthcheck_matcher
   health_check_grace_period_seconds = 180
 
+  # Pass health check configuration, including optional start period
+  task_healthcheck_interval     = var.task_healthcheck_interval
+  task_healthcheck_timeout      = var.task_healthcheck_timeout
+  task_healthcheck_retries      = var.task_healthcheck_retries
+  task_healthcheck_start_period  = var.task_healthcheck_start_period
+
   # Docker container details
   docker_registry   = var.docker_registry
   docker_repo       = local.docker_repo

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -4,3 +4,9 @@ aws_profile = "development-eu-west-2"
 required_cpus = 512
 required_memory = 1024
 service_autoscale_scale_out_cooldown = 600
+
+# task container healthcheck parameters
+task_healthcheck_interval = 60
+task_healthcheck_timeout = 10
+task_healthcheck_retries = 3
+task_healthcheck_start_period = 180

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -4,3 +4,9 @@ aws_profile = "live-eu-west-2"
 required_cpus = 1024
 required_memory = 2048
 service_autoscale_scale_out_cooldown = 600
+
+# task container healthcheck parameters
+task_healthcheck_interval = 60
+task_healthcheck_timeout = 10
+task_healthcheck_retries = 3
+task_healthcheck_start_period = 180

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -9,3 +9,9 @@ service_scaleup_schedule   = "5 6 * * ? *"
 required_cpus = 1024
 required_memory = 2048
 service_autoscale_scale_out_cooldown = 600
+
+# task container healthcheck parameters
+task_healthcheck_interval = 60
+task_healthcheck_timeout = 10
+task_healthcheck_retries = 3
+task_healthcheck_start_period = 180

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -135,3 +135,26 @@ variable "officers_search_consumer_version" {
   type        = string
   description = "The version of the officers-search-consumer service container to run."
 }
+
+# ------------------------------------------------------------------------------
+# Health check environment variable configs
+# ------------------------------------------------------------------------------
+variable "task_healthcheck_interval" {
+  type        = number
+  description = "Health check interval configuration for ECS task definitions."
+}
+
+variable "task_healthcheck_timeout" {
+  type        = number
+  description = "Health check timeout configuration for ECS task definitions."
+}
+
+variable "task_healthcheck_retries" {
+  type        = number
+  description = "Health check retries configuration for ECS task definitions."
+}
+
+variable "task_healthcheck_start_period" {
+  type        = number
+  description = "Health check start period configuration for ECS task definitions."
+}


### PR DESCRIPTION
This pull request introduces configurable ECS task container health check parameters across different environments in the `ecs-service` Terraform module. The main goal is to allow customization of health check intervals, timeouts, retries, and start periods for ECS service tasks.

The most important changes are:

**Health Check Parameter Support:**

* Added new variables for ECS task health check configuration (`task_healthcheck_interval`, `task_healthcheck_timeout`, `task_healthcheck_retries`, `task_healthcheck_start_period`) to `variables.tf`.
* Passed these new health check variables from the root module to the `ecs-service` module in `main.tf`.

**Environment-Specific Configuration:**

* Set the new health check parameters in the `development-eu-west-2/cidev` environment variables file.
* Set the new health check parameters in the `live-eu-west-2/live` environment variables file.
* Set the new health check parameters in the `staging-eu-west-2/staging` environment variables file.