### PR TITLE
Add missing WebMVC dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This pull request adds the `spring-boot-starter-webmvc` dependency to the `pom.xml` file. This change ensures that the core Spring MVC framework is included in the project, which is necessary for building web applications with Spring.

- Dependency management:
  * Added the `spring-boot-starter-webmvc` dependency to enable Spring MVC features in the application (`pom.xml`).